### PR TITLE
RouterInfo: don't throw on invalid RI size

### DIFF
--- a/src/core/router/info.cc
+++ b/src/core/router/info.cc
@@ -706,12 +706,14 @@ void RouterInfo::Verify()
 {
   try
     {
+      // Get RI length without signature
       std::size_t const len =
           m_Buffer.size() - m_RouterIdentity.GetSignatureLen();
-      if (len < Size::MinUnsignedBuffer)
-        throw std::length_error("RouterInfo: invalid RouterInfo size");
+
+      // Confirm if valid and usable
       const std::uint8_t* buf = m_Buffer.data();
-      if (!m_RouterIdentity.Verify(buf, len, &buf[len]))
+      if (len < Size::MinUnsignedBuffer
+          || !m_RouterIdentity.Verify(buf, len, &buf[len]))
         m_IsUnreachable = true;
     }
   catch (...)


### PR DESCRIPTION
Sanely, we would want to throw here but doing so will stop the router
instead of allowing the RI to become updated.

Referencing #917


---
**By submitting this pull-request, I confirm the following:**

- I have read and understood the developer guide in [kovri-docs](https://github.com/monero-project/kovri-docs).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.
---

